### PR TITLE
Fix a race condition in `freeRAM()`.

### DIFF
--- a/src/shray.c
+++ b/src/shray.c
@@ -137,8 +137,8 @@ static inline void freeRAM(uintptr_t start, uintptr_t end)
 
     DBUG_PRINT("We free [%p, %p[", (void *)start, (void *)end);
 
-    MUNMAP_SAFE((void *)start, end - start);
-    MMAP_FIXED_SAFE((void *)start, end - start, PROT_NONE);
+    MPROTECT_SAFE((void*)start, end - start, PROT_NONE);
+    MadviseDontNeedSafe((void*)start, end - start);
 }
 
 /* Simple binary search, assumes heap.allocs is sorted. */

--- a/src/shray.h
+++ b/src/shray.h
@@ -156,3 +156,13 @@ extern Heap heap;
             gasnet_exit(1);                                                   \
         }                                                                     \
     }
+
+static inline void MadviseDontNeedSafe(void *addr, size_t size) {
+  int r = madvise(addr, size, prot);
+  DBUG_PRINT("madvise: %d = madvise(%p, %zu, MADV_DONTNEED);,
+             r, addr, size);
+  if (r != 0) {
+    perror("madvise failed");
+    gasnet_exit(1);
+  }
+}

--- a/src/shray.h
+++ b/src/shray.h
@@ -158,8 +158,8 @@ extern Heap heap;
     }
 
 static inline void MadviseDontNeedSafe(void *addr, size_t size) {
-  int r = madvise(addr, size, prot);
-  DBUG_PRINT("madvise: %d = madvise(%p, %zu, MADV_DONTNEED);,
+  int r = madvise(addr, size, MADV_DONTNEED);
+  DBUG_PRINT("madvise: %d = madvise(%p, %zu, MADV_DONTNEED);",
              r, addr, size);
   if (r != 0) {
     perror("madvise failed");


### PR DESCRIPTION
Previously `freeRAM()` did
```
 munmap(addr, size);
 mmap(addr, size, ..., PROT_NONE, MAP_FIXED, ...);
```

There's a race there: if another thread calls `mmap()`, it could get ahold of that page, and then your `mmap` call will misbehave.

Instead do this:
```
 mprotect(addr, size, PROT_NONE)
 madvise(addr, size, MADV_DONTNEED)
```

I need an madvise function, and added `MadviseDontNeedSafe` to `shray.h`, as a static inline function rather than `MADVISE_DONTNEED_SAFE` as a macro.  It looks like most of the logic in `shray.h` would be just as fast implemented as functions instead of macros, and they would be less error prone.